### PR TITLE
fix: add index.js to register root component — fixes Android crash

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+import { registerRootComponent } from 'expo';
+import App from './App';
+
+// registerRootComponent calls AppRegistry.registerComponent('main', () => App);
+// It also ensures that whether you load the app in Expo Go or in a native build,
+// the environment is set up appropriately.
+registerRootComponent(App);

--- a/package.json
+++ b/package.json
@@ -36,5 +36,5 @@
   },
   "name": "story-time",
   "version": "1.0.0",
-  "main": "App.tsx"
+  "main": "index.js"
 }


### PR DESCRIPTION
## Problem
The app was crashing on Android with:
```
Invariant Violation: "main" has not been registered
```

## Root Cause
`MainActivity.kt` calls `getMainComponentName()` which returns `"main"`. React Native uses this to look up a registered component via `AppRegistry`. Without an `index.js` that calls `registerRootComponent` (which internally calls `AppRegistry.registerComponent('main', () => App)`), the JS bundle loads `App.tsx` as just a module export — the bridge never gets the registration, and the app crashes immediately on launch.

`package.json` was also pointing `"main"` to `App.tsx` directly, bypassing the registration step entirely.

## Fix
- Added `index.js` using Expo's `registerRootComponent`
- Updated `package.json` `"main"` to point to `index.js`

## Testing
Build the Android APK and launch — should no longer crash on start.